### PR TITLE
Support other python versions than python 39

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -93,8 +93,8 @@ testWin_2.0:
   
 testLinux_2.0:
   stage: test_2.0
-  tags: ["linux", "docker"]
-  image: at-twk-hal9000.intra.dlr.de:5000/dlr-at/gtlabdev-2_0-buster
+  extends:
+    - .linuxdocker
   needs: ["linuxBuildDebug_2.0"]
   before_script:
     # update to latest dev tools
@@ -115,10 +115,9 @@ testLinux_2.0:
 
 .code-coverage:
   stage: codequality
-  tags: ["linux", "docker"]
-  image: at-twk-hal9000.intra.dlr.de:5000/dlr-at/gtlabdev-2_0-buster
   extends: 
     - .build-linux_20
+    - .linuxdocker
   script:
     - apt install -y libglu1-mesa
     - cmake -B build -S . -G "Ninja" -DCMAKE_BUILD_TYPE=Debug -DGTLAB_DEVTOOLS_DIR=$GTLAB_DEV_TOOLS -DBUILD_UNITTESTS=ON -DBUILD_WITH_COVERAGE=ON
@@ -142,9 +141,9 @@ cppcheck:
 
 check-license:
    stage: codequality
-   tags: ["docker", "linux"]
    needs: []
-   image: at-twk-hal9000.intra.dlr.de:5000/dlr-at/buster-dev
+   extends:
+     - .linuxdocker
    before_script:
     - python3 -m pip install reuse
    script:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+### Added
+ - Added support for python modules compiled with python versions other than 3.9
+
 ## [0.5.0] - 2025-07-13
 ### Added
  - Added the node name prefix to `print()` messages, to improve

--- a/src/gtpn_module.json
+++ b/src/gtpn_module.json
@@ -1,6 +1,6 @@
 {
     "dependencies": [
-		{ "name" : "Python Module (Python 3.9)", "version" : "1.8.0" },
+		{ "name" : "regex:Python Module", "version" : "1.8.0" },
 		{ "name" : "IntelliGraph", "version" : "0.14.0" }
     ]
 }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

This adds support for python module version compiled with other python versions by using a regex for the dependencies.

## How Has This Been Tested?

Locally.


## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. -->
- [ ] A test for the new functionality was added (if applicable).
- [ ] All tests run without failure.
- [ ] The changelog has been extended, if this MR contains important changes from the users's point of view.
- [ ] The new code complies with the GTlab's style guide.
- [ ] New interface methods / functions are exported via `EXPORT`. Non-interface functions are NOT exported.
- [ ] The number of code quality warnings is not increasing.
