### PR TITLE
Add support for Qt6

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -93,8 +93,8 @@ testWin_2.0:
   
 testLinux_2.0:
   stage: test_2.0
-  tags: ["linux", "docker"]
-  image: at-twk-hal9000.intra.dlr.de:5000/dlr-at/gtlabdev-2_0-buster
+  extends:
+    - .linuxdocker
   needs: ["linuxBuildDebug_2.0"]
   before_script:
     # update to latest dev tools
@@ -115,10 +115,9 @@ testLinux_2.0:
 
 .code-coverage:
   stage: codequality
-  tags: ["linux", "docker"]
-  image: at-twk-hal9000.intra.dlr.de:5000/dlr-at/gtlabdev-2_0-buster
   extends: 
     - .build-linux_20
+    - .linuxdocker
   script:
     - apt install -y libglu1-mesa
     - cmake -B build -S . -G "Ninja" -DCMAKE_BUILD_TYPE=Debug -DGTLAB_DEVTOOLS_DIR=$GTLAB_DEV_TOOLS -DBUILD_UNITTESTS=ON -DBUILD_WITH_COVERAGE=ON
@@ -142,9 +141,9 @@ cppcheck:
 
 check-license:
    stage: codequality
-   tags: ["docker", "linux"]
+   extends:
+     - .linuxdocker
    needs: []
-   image: at-twk-hal9000.intra.dlr.de:5000/dlr-at/buster-dev
    before_script:
     - python3 -m pip install reuse
    script:

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -19,17 +19,26 @@ set(CMAKE_CXX_EXTENSIONS OFF)
 set(CMAKE_MODULE_PATH ${PROJECT_SOURCE_DIR}/cmake)
 set(CMAKE_AUTOMOC ON)
 
-set(Qt5_DIR ${QT_DIR})
-
-find_package(Qt5 REQUIRED COMPONENTS Widgets Core Gui Xml Svg)
-
 find_package(Python3 REQUIRED COMPONENTS Development)
 set(Python3_VERSION_SUFFIX "${Python3_VERSION_MAJOR}${Python3_VERSION_MINOR}")
 
-include(GTlab)
+if (GTLAB_DEVTOOLS_DIR AND NOT GTlabDevtools_ROOT)
+    message(WARNING "GTLAB_DEVTOOLS_DIR is deprecated. Use GTlabDevtools_ROOT instead.")
+    set(GTlabDevtools_ROOT ${GTLAB_DEVTOOLS_DIR})
+endif()
 
+find_package(GTlabDevtools QUIET)
+
+include(GTlab)
 gtlab_standard_setup()
-enable_gtlab_devtools()
+
+require_qt(COMPONENTS Widgets Core Gui Xml Svg)
+
+# include SvgWidget, if Qt major version is 6 or higher
+if (QT_VERSION_MAJOR GREATER_EQUAL 6)
+    require_qt(COMPONENTS SvgWidgets)
+endif()
+
 
 if(NOT TARGET GTlab::Core)
     find_package(GTlab REQUIRED)

--- a/cmake/GTlab.cmake
+++ b/cmake/GTlab.cmake
@@ -167,3 +167,100 @@ function(add_gtlab_module GTLAB_ADD_MODULE_TARGET)
   endif()
 
 endfunction()
+
+# ==============================================================================
+# require_qt(
+#   COMPONENTS <comp>...
+# )
+#
+# Summary:
+#   Locate and configure a single Qt major version (5 or 6) for the entire
+#   build and ensure the requested components are available.
+#
+# Behavior:
+#   - Uses Qt’s “dual version” pattern:
+#       find_package(QT NAMES Qt6 Qt5 REQUIRED COMPONENTS <components>)
+#       find_package(Qt${QT_VERSION_MAJOR} REQUIRED COMPONENTS <components>)
+#
+#   - On the first call, if QT_VERSION_MAJOR is NOT defined:
+#       * If Qt has already been found by the parent project
+#         (e.g. via find_package(QT ...) or find_package(Qt6/Qt5 ...)),
+#         QT_VERSION_MAJOR is taken from the existing Qt configuration or
+#         inferred from existing Qt6::*/Qt5::* targets.
+#       * Otherwise, require_qt() calls:
+#             find_package(QT NAMES Qt6 Qt5 REQUIRED COMPONENTS <components>)
+#         which sets QT_VERSION_MAJOR to 5 or 6 according to what CMake
+#         finds on the search path.
+#       * QT_VERSION_MAJOR is then cached so all subsequent calls reuse
+#         the same major version.
+#
+#   - On subsequent calls (QT_VERSION_MAJOR already defined):
+#       * require_qt() simply calls:
+#             find_package(Qt${QT_VERSION_MAJOR} REQUIRED COMPONENTS <components>)
+#         to make sure the requested modules for the chosen major are available.
+#
+# Guarantees:
+#   - All callers (core and modules) in a single build tree use the same Qt
+#     major version, as determined by the first successful Qt detection.
+#   - If the requested Qt components for that major cannot be found,
+#     configuration fails with an error.
+#
+# User control of the chosen Qt version:
+#   - Standard CMake mechanisms apply. The user can steer which Qt is found by:
+#       * Adjusting CMAKE_PREFIX_PATH / Qt installation order (preferred), or
+#       * Setting Qt5_DIR / Qt6_DIR to point at a specific Qt installation
+#
+# Notes:
+#   - This function does NOT create versionless Qt:: targets. Callers are
+#     expected to link against versioned targets, e.g.:
+#         Qt${QT_VERSION_MAJOR}::Core
+#         Qt${QT_VERSION_MAJOR}::Widgets
+#         Qt${QT_VERSION_MAJOR}::<OtherComponent>
+# ==============================================================================
+function(require_qt)
+    set(options)
+    set(oneValueArgs)
+    set(multiValueArgs COMPONENTS)
+    cmake_parse_arguments(RQT "${options}" "${oneValueArgs}" "${multiValueArgs}" ${ARGN})
+
+    if (NOT RQT_COMPONENTS)
+        message(FATAL_ERROR "require_qt() called without COMPONENTS")
+    endif()
+    
+    # --------------------------------------------------------
+    # 1. Decide QT_VERSION_MAJOR once
+    # --------------------------------------------------------
+    if (NOT DEFINED QT_VERSION_MAJOR)
+
+        # 1a) If user hinted a specific major via Qt6_DIR / Qt5_DIR, respect that
+        if (DEFINED Qt6_DIR AND NOT DEFINED Qt5_DIR)
+            set(QT_VERSION_MAJOR 6)
+        elseif (DEFINED Qt5_DIR AND NOT DEFINED Qt6_DIR)
+            set(QT_VERSION_MAJOR 5)
+
+        elseif (DEFINED Qt5_DIR AND DEFINED Qt6_DIR)
+            set(QT_VERSION_MAJOR 6)
+        else()
+            # 1b) No specific *_DIR hints: use the standard Qt dual-version pattern
+            #     This will honor QT_DIR, CMAKE_PREFIX_PATH, etc.
+            find_package(QT NAMES Qt6 Qt5 REQUIRED COMPONENTS ${RQT_COMPONENTS})
+        endif()
+
+        # One-time status message
+        if (NOT DEFINED GTLAB_QT_VERSION_REPORTED AND DEFINED QT_VERSION_MAJOR)
+            message(STATUS "GTlab: using Qt${QT_VERSION_MAJOR} for this build")
+            set(GTLAB_QT_VERSION_REPORTED TRUE CACHE INTERNAL
+                "Whether the selected Qt version has been reported")
+        endif()
+    endif()
+
+    if (NOT DEFINED QT_VERSION_MAJOR)
+        message(FATAL_ERROR
+            "require_qt(): QT_VERSION_MAJOR is still undefined after detection. "
+            "Check your Qt hints: QT_DIR, Qt5_DIR, Qt6_DIR, CMAKE_PREFIX_PATH.")
+    endif()
+
+    # actually find qt
+    find_package(Qt${QT_VERSION_MAJOR} REQUIRED COMPONENTS ${RQT_COMPONENTS})
+    set (QT_VERSION_MAJOR ${QT_VERSION_MAJOR} PARENT_SCOPE)
+endfunction()

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -37,15 +37,22 @@ add_gtlab_module(PythonNode SOURCES ${HEADERS} ${SOURCES} ${RESOURCES}
 target_link_libraries(PythonNode
     PUBLIC GTlab::IntelliGraph
     PRIVATE
-    Qt5::Widgets
-    Qt5::Gui
-    Qt5::Xml
-    Qt5::Svg
+    Qt${QT_VERSION_MAJOR}::Widgets
+    Qt${QT_VERSION_MAJOR}::Gui
+    Qt${QT_VERSION_MAJOR}::Xml
+    Qt${QT_VERSION_MAJOR}::Svg
     GTlab::Logging
     GTlab::Core
     GTlab::Gui
     GTlab::Python
 )
+
+# include SvgWidgets, if Qt major version is 6 or higher
+if (QT_VERSION_MAJOR GREATER_EQUAL 6)
+    target_link_libraries(PythonNode
+        PRIVATE Qt6::SvgWidgets
+    )
+endif()
 
 add_library(GTlab::PythonNode ALIAS PythonNode)
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

This adds support for Qt6.

 - No actual code changes were required, just the build system.

## How Has This Been Tested?

Locally

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. -->
- [ ] A test for the new functionality was added (if applicable).
- [ ] All tests run without failure.
- [ ] The changelog has been extended, if this MR contains important changes from the users's point of view.
- [ ] The new code complies with the GTlab's style guide.
- [ ] New interface methods / functions are exported via `EXPORT`. Non-interface functions are NOT exported.
- [ ] The number of code quality warnings is not increasing.
